### PR TITLE
Add research docs, business data, and MCP server

### DIFF
--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,13 @@
+# Research Workspace
+
+Working area for market research and fundraising. Start with `TASKS.md` and fill sources as you go. Output should feed Investor Mode (Business Plan explorer), the deck (`/investor-deck`), and the data room.
+
+Key files
+- `TASKS.md` — master backlog
+- `segments.md` — segment definitions and use cases
+- `revenue_projections.csv` — per-customer projection scenarios (low/base/high)
+- `sources.md` — source links (replace placeholders with real citations)
+- `org-structures.md` — structure options and governance considerations
+- `international-expansion.md` — country kits and sources
+- `microdata-demand.md` — data product opportunities and validation
+

--- a/docs/research/TASKS.md
+++ b/docs/research/TASKS.md
@@ -1,0 +1,82 @@
+# Market Research Master Task List
+
+This is a working backlog to support fundraising and strategy. Use checkboxes to track progress and add links/evidence as you go. Keep everything source-linked where possible.
+
+## 0. Program Management
+- [ ] Define owners per workstream (Customers, Revenue, Data, Product, Legal, GTM)
+- [ ] Set weekly milestones and a shared dashboard (metrics + links)
+- [ ] Maintain decision log (assumptions, tradeoffs, approvals)
+
+## 1. Customers and Users (Discovery + Validation)
+- [ ] Catalog all current/past users of PolicyEngine (org, contact, usage, status)
+- [ ] Verify external users mentioned: MyFriendBen, Benefit Navigator, Impactica/Navvy, Mirza, The Tax Project, Prenatal-to-3 Policy Impact Center (Pn3 PIC)
+- [ ] Identify other users of rules-only (accountants, tax pros, consultancies, government policy teams)
+- [ ] Identify users of “rules-as-data” for AI retrieval/grounding (LLM assistants)
+- [ ] Identify users of enhanced microdata (market research, retail, mobility, public health)
+- [ ] Interview plan: 10+ target users per segment; capture problem, workflow, budget, procurement, success criteria
+- [ ] Create reference pipeline: permission to publish quotes, logo usage, and case studies
+
+## 2. Revenue Projections (Per Segment and Per Customer)
+- [ ] Define pricing axes: hosted instance, SLA tier, usage (runs/MAUs/compute), seats, services
+- [ ] Build scenarios: conservative/base/aggressive for each customer and segment
+- [ ] Fill `docs/research/revenue_projections.csv` with low/base/high per customer (assumptions + source links)
+- [ ] Validate with existing customers; get willingness-to-pay ranges
+- [ ] Unit economics: infra cost per run, support load per instance, gross margin targets
+
+## 3. Segments (Sizing + Prioritization)
+- [ ] Government policy teams: fiscal notes, scoring, distributional analysis (US federal/state; UK HMT/HMRC)
+- [ ] Program operators: eligibility/adjudication/audit (Medicaid, SNAP, HMRC benefits)
+- [ ] Accounting firms: tax prep, withholding, advisory; payroll platforms
+- [ ] Consultancies: rapid policy scoring + decks; research teams
+- [ ] Fintech/benefits apps: embedded calculators, eligibility flows
+- [ ] AI/LLM: policy reasoning; rules-as-data APIs
+- [ ] Research institutes/think-tanks: reproducible analysis
+- [ ] Market research/retail: demand estimation with enriched microdata
+- [ ] Prioritize by demand signals, time-to-value, strategic leverage, adjacency
+
+## 4. Competitive Landscape
+- [ ] OSS: OpenFisca, PSL/Tax-Calculator, OpenM++, LIAM2, JAS-MINE; capture license, pricing, adoption, strengths/weaknesses
+- [ ] Proprietary: EUROMOD, TAXSIM (model/service scope), SPSD/M; procurement patterns
+- [ ] Substitute products: in-house Excel/R/Python models; consulting deliverables
+- [ ] Moat articulation: transparency, versioned rules, provenance, auditability, developer experience
+
+## 5. Product & Data (Roadmap Evidence)
+- [ ] Rules coverage metrics: jurisdictions, parameters, change-latency SLOs (define and publish)
+- [ ] Data pipeline: integrate consumption data; list credible sources and legal access paths
+- [ ] Dynamics (behavioral/GE): roadmap with validation plan and benchmarks
+- [ ] Developer experience: docs, quickstarts, SDK ergonomics, sample notebooks
+- [ ] Audit & provenance UX: diffs, citations, evidence capture in YAML
+
+## 6. Pricing & Packaging
+- [ ] Hosted enterprise tiers (SLA, instances, support hours, compliance)
+- [ ] API pricing: MAUs + compute; free tier policy; overage pricing
+- [ ] Seats for advisory tooling; consulting day rates and accelerators
+- [ ] Discount framework for nonprofits/academia/government
+
+## 7. Org Structure & OSS Model
+- [ ] Compare models: single C‑Corp/PBC vs. Foundation + wholly-owned subsidiary (Mozilla-style)
+- [ ] Governance and trademark rules; CLA/DCO policy; contributor governance
+- [ ] Funding models: support subscriptions (Red Hat), enterprise add-ons (GitLab/Confluent analogs), services
+- [ ] Draft recommendation memo with pros/cons and legal to-dos
+
+## 8. International Expansion
+- [ ] Shortlist countries (US/UK/CA baseline; EU exemplars; AU/NZ)
+- [ ] For each: rules source, data source, calibration plan, partner leads
+- [ ] Create “country kits” with links, effort estimates, and pilot user list
+
+## 9. Partnerships
+- [ ] Universities, agencies, foundations—pipeline and sponsorship options
+- [ ] Data partnerships for microdata and consumption augmentation
+- [ ] Cloud marketplace listings; compliance roadmap
+
+## 10. Deck & Data Room
+- [ ] Deck refresh: problem, solution, product, market size, traction, model, roadmap, competition, team, ask
+- [ ] Metrics appendix: usage, coverage, uptime, release cadence
+- [ ] Case studies & reference letters
+- [ ] Financial model + hiring plan
+- [ ] Legal: OSS licenses, IP ownership, CLAs, privacy policy
+
+---
+
+Use this list as the single source of truth. Pull concise action items into weekly sprints. Add sources and evidence as you go.
+

--- a/docs/research/international-expansion.md
+++ b/docs/research/international-expansion.md
@@ -1,0 +1,31 @@
+# International Expansion Plan (Draft)
+
+Goal: prioritize countries where we can deliver credible rules + microdata quickly and win early users/partners.
+
+## Prioritization Criteria
+- Demand signals (partners, pilots, inbound)
+- Rules source availability and complexity
+- Microdata availability and calibration feasibility
+- Language, legal, and hosting constraints
+- Reuse of US/UK components (architecture, pipeline)
+
+## Shortlist and Leads
+- Canada (CA): federal and provinces (SPSD/M context); partners in academia/government
+- Ireland/Netherlands/Germany (EU exemplars): EU-SILC access; select one to start
+- Australia/New Zealand: ABS/NZ Stats microdata; English docs; policy interest
+- Later: Spain/France/Italy/Poland (EU); India; Brazil; South Africa — contingent on partners
+
+## Data and Rules Sources (Leads)
+- EU-SILC (EU microdata): https://ec.europa.eu/eurostat/web/microdata/european-union-statistics-on-income-and-living-conditions
+- UK FRS (Family Resources Survey): https://ukdataservice.ac.uk/
+- Canada SPSD/M (inputs and methods): https://www.statcan.gc.ca/eng/microsimulation/spsdm
+- Australia (ABS HES): https://www.abs.gov.au/statistics/economy/finance
+- New Zealand (HES): https://www.stats.govt.nz/
+
+## Country Kit Template (create per target)
+- Rules inventory + sources
+- Data inventory + access path + license terms
+- Calibration plan (inputs, targets, validation steps)
+- Candidate early users + partners + funding angle
+- Effort estimate and timeline (MVP; production)
+

--- a/docs/research/microdata-demand.md
+++ b/docs/research/microdata-demand.md
@@ -1,0 +1,21 @@
+# Enhanced Microdata Demand (Draft)
+
+Objective: map out demand for enriched synthetic microdata (with consumption) across sectors and define productization.
+
+## Sectors and Use Cases
+- Market research: local demand estimation, price elasticity, segment targeting
+- Retail: store footprint planning, assortment, promo optimization
+- Mobility/transport: transit fare and policy impacts on households
+- Public health: eligibility + uptake modeling for health programs
+- Energy/utilities: tariff impacts by household type; consumption shifts
+
+## Data Product Candidates
+- County-level synthetic households with demographics, income, taxes/benefits, and consumption vectors
+- Scenario API: ingest policy changes; output demand shifts and distributional effects
+- Cohort tagging: custom segments for partners (privacy-preserving)
+
+## Validation Tasks
+- Identify credible consumption sources (e.g., BLS CEX) and licensing
+- Document augmentation method; publish validation metrics (fit, coverage)
+- Pilot studies with 2–3 partners (market research firm, retailer, public agency)
+

--- a/docs/research/org-structures.md
+++ b/docs/research/org-structures.md
@@ -1,0 +1,36 @@
+# Organizational Structure Options (Draft)
+
+This memo outlines options for Cosilico’s structure with pros/cons and open questions.
+
+## Option A: Single For‑Profit (C‑Corp or PBC)
+- Pros: simplicity, velocity, single board; straightforward fundraising
+- Cons: perception risk for OSS stewardship; conflicts between commercial and neutral governance
+- Notes: PBC charter can encode mission; requires careful trademark and governance policy
+
+## Option B: Foundation + Wholly-Owned Sub (Mozilla‑style)
+- Foundation (501(c)(3) or similar) owns IP, trademarks; sets governance for open-source core
+- For‑profit subsidiary (C‑Corp or PBC) executes commercial work (hosted, SLAs, integrations)
+- Pros: clear separation of stewardship vs. commercialization; durable neutrality
+- Cons: more overhead; legal complexity; fundraising split
+
+## Option C: Independent Foundation + Separate Operating Company
+- Foundation holds trademarks, community governance; operating company licenses brand/IP
+- Pros: strong neutrality; community trust
+- Cons: coordination costs; licensing agreements; dual fundraising
+
+## Governance Considerations
+- Contributor agreements (CLA/DCO); code of conduct; RFC process; release governance
+- Trademark policy ("Built on Cosilico"); brand usage guide
+- Security and disclosure policy; compliance roadmap (SOC2/ISO27001 later)
+
+## Business Model Patterns (Analogies)
+- Red Hat: subscription/support for enterprise deployments of OSS
+- GitLab/Confluent: open-core with enterprise features and hosted SaaS
+- Mozilla: foundation stewardship with commercial subsidiary; revenue from partnerships/licensing
+
+## Next Steps
+- Draft recommended structure with legal counsel
+- Define trademark and contributor policies
+- Identify board composition and conflict-of-interest policy
+- Prepare community charter, governance docs, and CLA/DCO templates
+

--- a/docs/research/revenue_projections.csv
+++ b/docs/research/revenue_projections.csv
@@ -1,0 +1,16 @@
+id,label,segment,region,pricing_model,assumptions,low,base,high,notes
+cust_policyengine,PolicyEngine Nonprofit,Flagship,US/UK,Hosted+SLA,"Base fee + support; shared roadmap",0,0,0,"Grant-funded; non-revenue oriented; may fund platform indirectly"
+cust_myfriendben,MyFriendBen,Fintech,US,API+MAUs,"Assume X MAUs, Y runs/user, $/1k runs","=X*Y*price*0.5","=X*Y*price","=X*Y*price*1.5","Fill X,Y,price; validate with team"
+cust_benefitnav,Benefit Navigator,Fintech,US,API+MAUs,"Assume X MAUs, Y runs/user, $/1k runs","","","",""
+cust_impactica,Impactica (Navvy),Civic/Student,US,API+MAUs,"Pilot → platform","","","",""
+cust_mirza,Mirza,Fintech/Advisory,UK,API+Seats,"Seats for advisory + API bundles","","","",""
+cust_taxproject,The Tax Project,Media/Research,US,Hosted or API,"Runs for calculators; sponsorship","","","",""
+cust_accounting,Accounting Firms,Accounting,US/UK,Seats+API+Hosted,"Tiered by firm size, attach rate","","","",""
+cust_tax_consult,Tax Consultancies,Consulting,US/UK,Project+Platform,"Per-project platform fee","","","",""
+cust_gov,Government Agencies,Policy Teams,US,Hosted+SLA,"Instance per agency; support hours","","","","Procurement cycles"
+cust_gov_ops,Gov Program Operators,Benefits Ops,US/UK,Private Deployments,"Eligibility/adjudication system integration","","","",""
+cust_ai,AI Companies,AI,Global,Usage API,"RAG + structured rules; high variance","","","",""
+cust_research,Research Institutes,Academia,Global,Institutional,"Campus-wide license or group instance","","","",""
+cust_fintech,Fintech Apps,Fintech,US,API+MAUs,"Multiple small-to-medium apps","","","",""
+
+# Guidance: replace blanks with numeric scenarios. Use spreadsheet to evaluate. Keep assumptions concise and add source links in docs/research/sources.md.

--- a/docs/research/segments.md
+++ b/docs/research/segments.md
@@ -1,0 +1,41 @@
+# Customer Segments and Use Cases
+
+This file enumerates segments, use cases, and example workflows to guide interviews and sizing. Link each item to evidence sources as they’re collected.
+
+## Government Policy Teams
+- Use cases: scoring proposals, distributional analysis, fiscal notes
+- Users: legislative staff, budget/fiscal analysts, HMT/HMRC analysts
+- Procurement: RFPs/contracts; often 6–18 month cycles
+- Pricing anchors: enterprise hosted instance + SLAs; support hours
+
+## Program Operators (Benefits)
+- Use cases: eligibility rules, adjudication logic, audit trails, change tracking
+- Users: program administrators, IT modernization vendors
+- Pricing anchors: hosted/private deployments; support + compliance
+
+## Accounting Firms / Payroll Platforms
+- Use cases: rules-as-data for tax prep/advisory; withholding and payroll logic
+- Users: firm advisory teams; payroll product teams
+- Pricing anchors: seats + API usage; enterprise instances for large firms
+
+## Consultancies (Policy/Tax)
+- Use cases: rapid policy scoring; presentation-grade outputs; reproducible methods
+- Pricing anchors: per-project platform fees; reference architectures
+
+## Fintech/Benefits Apps
+- Use cases: embedded calculators, eligibility flows, onboarding
+- Pricing anchors: MAUs + compute; free tier for civic use
+
+## AI/LLM Companies
+- Use cases: retrieval-augmented policy reasoning; structured rules APIs
+- Pricing anchors: usage-based APIs; enterprise data entitlements
+
+## Research Institutes/Think-Tanks
+- Use cases: reproducible policy analysis; open methods; journal replication
+- Pricing anchors: institutional licenses; hosted instances for research groups
+
+## Market Research / Retail (with enriched microdata)
+- Use cases: local demand estimation; policy-driven demand shifts by county
+- Data: household microdata + consumption augmentation; synthetic privacy-preserving approach
+- Pricing anchors: data subscriptions; model-as-a-service; bespoke analyses
+

--- a/docs/research/sources.md
+++ b/docs/research/sources.md
@@ -1,0 +1,40 @@
+# Source Leads (to validate and cite)
+
+Add links and brief notes as you research. Use these as starting points; replace with better sources as you find them.
+
+## Users / Prospects
+- MyFriendBen — https://myfriendben.org/ (confirm product scope and PolicyEngine usage)
+- Benefit Navigator — candidate: https://benefitsnavigator.org/ (verify correct org/name)
+- Impactica (Navvy) / Student Basic Needs Coalition — https://www.subu.org/orgs/21392/ or project materials (confirm URL and scope)
+- Mirza — https://www.ourmirza.com/ (confirm current product and policy focus)
+- The Tax Project — https://www.thetaxproject.com/ (confirm calculators and backend)
+- Prenatal-to-3 Policy Impact Center — https://pn3policy.org/ (verify engagement and use cases)
+
+## OSS / Competitors
+- OpenFisca — https://openfisca.org/
+- PSL / Tax-Calculator — https://pslmodels.org/ and https://github.com/PSLmodels/Tax-Calculator
+- NBER TAXSIM — https://taxsim.nber.org/
+- EUROMOD — https://euromod-web.jrc.ec.europa.eu/
+- SPSD/M (Statistics Canada) — https://www.statcan.gc.ca/eng/microsimulation/spsdm
+- OpenM++ — https://github.com/openmpp/openmpp.github.io
+- LIAM2 — https://liam2.plan.be/
+- JAS-MINE — https://www.jas-mine.net/
+
+## Microdata / Calibration
+- US CPS/ACS — https://www.census.gov/programs-surveys/acs/
+- UK Family Resources Survey (FRS) — https://ukdataservice.ac.uk/
+- EU-SILC — https://ec.europa.eu/eurostat/web/microdata/european-union-statistics-on-income-and-living-conditions
+- Canada SPSD/M inputs — see Statistics Canada documentation
+- Consumption augmentation ideas: BLS Consumer Expenditure Survey — https://www.bls.gov/cex/
+
+## OSS Business Models and Structures
+- Red Hat subscription/support model — https://en.wikipedia.org/wiki/Red_Hat#Business_model
+- Mozilla Foundation + Mozilla Corporation — https://www.mozilla.org/en-US/foundation/ and https://www.mozilla.org/en-US/about/governance/
+- Public Benefit Corporation (PBC) overview — https://en.wikipedia.org/wiki/Benefit_corporation (seek legal guidance for jurisdiction)
+- GitLab (open-core) — https://about.gitlab.com/company/ (pricing and governance)
+- Confluent (Kafka) — https://www.confluent.io/pricing/ (open-core, enterprise add-ons)
+
+## Government Procurement / Budgets (examples)
+- US state RFP portals; fiscal note processes (collect links per state)
+- UK Crown Commercial Service frameworks — https://www.crowncommercial.gov.uk/
+

--- a/docs/research/users/_template.md
+++ b/docs/research/users/_template.md
@@ -1,0 +1,26 @@
+# {label}
+
+Segment: {segment}
+Region: {region}
+Status: {status}
+
+## Quick Facts
+- Contact(s): TBD
+- Product fit: {use_cases}
+- Current usage: TBD
+
+## Revenue Projection Inputs
+- Pricing model: {pricing}
+- Assumptions: {assumptions}
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Primary source link (website, docs)
+- [ ] Usage confirmation (email/contract)
+- [ ] Budget/Spend estimate
+
+## Next Actions
+- [ ] Intro meeting / discovery
+- [ ] Validate workflow and success criteria
+- [ ] Pilot or LOI terms
+

--- a/docs/research/users/accounting-firms.md
+++ b/docs/research/users/accounting-firms.md
@@ -1,0 +1,25 @@
+# Accounting Firms
+
+Segment: Accounting/Advisory
+Region: US/UK
+Status: In Progress (segment discovery)
+
+## Quick Facts
+- Contacts: Big 4 + Tier-2 firm innovation/advisory leads
+- Product fit: Rules-as-Data; Tax Prep & Advisory; Payroll & Withholding
+
+## Revenue Projection Inputs
+- Pricing model: Seats + API bundles + hosted instance for large firms
+- Assumptions: attach rate by firm size; usage per seat
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Firm counts and segmentation (US/UK)
+- [ ] Advisory attach rate benchmarks
+- [ ] Budget/Spend estimate per firm tier
+
+## Next Actions
+- [ ] Outreach to firm innovation leads
+- [ ] Pilot design and data governance review
+- [ ] Pricing validation
+

--- a/docs/research/users/benefit-navigator.md
+++ b/docs/research/users/benefit-navigator.md
@@ -1,0 +1,26 @@
+# Benefit Navigator
+
+Segment: Fintech (Benefits)
+Region: US
+Status: Validated (confirm)
+
+## Quick Facts
+- Contact(s): TBD
+- Product fit: Benefit Eligibility; Rules-as-Data
+- Current usage: TBD (confirm API integration)
+
+## Revenue Projection Inputs
+- Pricing model: API + MAUs
+- Assumptions: MAUs, runs/user, $/1k runs; intake seasonality
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Website: https://benefitsnavigator.org/ (confirm correct org)
+- [ ] Usage confirmation
+- [ ] Budget/Spend estimate
+
+## Next Actions
+- [ ] Intro or reconfirm scope
+- [ ] Define pilot KPI and timeline
+- [ ] Pricing discussion and SOW/LOI
+

--- a/docs/research/users/impactica-navvy.md
+++ b/docs/research/users/impactica-navvy.md
@@ -1,0 +1,26 @@
+# Impactica (Navvy)
+
+Segment: Civic/Student Basic Needs
+Region: US
+Status: Validated (confirm)
+
+## Quick Facts
+- Contact(s): TBD
+- Product fit: Benefit Eligibility; Benefit Application Orchestration
+- Current usage: TBD (confirm API integration)
+
+## Revenue Projection Inputs
+- Pricing model: API + MAUs (partnered program)
+- Assumptions: MAUs via campus rollouts; runs/user; $/1k runs
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Org/project links (confirm authoritative URL)
+- [ ] Usage confirmation
+- [ ] Budget/Spend estimate
+
+## Next Actions
+- [ ] Intro or reconfirm scope
+- [ ] Define pilot KPI and timeline
+- [ ] Pricing discussion and SOW/LOI
+

--- a/docs/research/users/market-research-orgs.md
+++ b/docs/research/users/market-research-orgs.md
@@ -1,0 +1,23 @@
+# Market Research Organizations
+
+Segment: Data/Analytics
+Region: US initially
+Status: Prospect (segment)
+
+## Quick Facts
+- Contacts: market research firms with geographic segmentation products
+- Product fit: Local Demand Estimation; Rules-as-Data (policy effects)
+
+## Revenue Projection Inputs
+- Pricing model: data subscriptions + scenario API
+- Assumptions: # clients; subscription per client; usage
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Prospective firm list
+- [ ] Data sourcing/legal review (consumption augmentation)
+
+## Next Actions
+- [ ] Pilot study design (2–3 partners)
+- [ ] Publish validation metrics and demos
+

--- a/docs/research/users/mirza.md
+++ b/docs/research/users/mirza.md
@@ -1,0 +1,26 @@
+# Mirza
+
+Segment: Fintech/Advisory (Childcare affordability)
+Region: UK
+Status: In Progress (confirm)
+
+## Quick Facts
+- Contact(s): TBD
+- Product fit: Benefit Eligibility; Tax Calculator; Rules-as-Data
+- Current usage: TBD (confirm API integration)
+
+## Revenue Projection Inputs
+- Pricing model: Seats + API bundles
+- Assumptions: seats per advisory team; API bundle size
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Website: https://www.ourmirza.com/
+- [ ] Usage confirmation
+- [ ] Budget/Spend estimate
+
+## Next Actions
+- [ ] Intro or reconfirm scope
+- [ ] Define pilot KPI and timeline
+- [ ] Pricing discussion and SOW/LOI
+

--- a/docs/research/users/myfriendben.md
+++ b/docs/research/users/myfriendben.md
@@ -1,0 +1,26 @@
+# MyFriendBen
+
+Segment: Fintech (Benefits)
+Region: US
+Status: Validated (confirm)
+
+## Quick Facts
+- Contact(s): TBD
+- Product fit: Benefit Eligibility; Tax Calculator; Rules-as-Data
+- Current usage: TBD (confirm API integration)
+
+## Revenue Projection Inputs
+- Pricing model: API + MAUs
+- Assumptions: MAUs, runs/user, $/1k runs; eligibility spike seasonality
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Website: https://myfriendben.org/
+- [ ] Usage confirmation
+- [ ] Budget/Spend estimate
+
+## Next Actions
+- [ ] Intro or reconfirm scope
+- [ ] Define pilot KPI and timeline
+- [ ] Pricing discussion and SOW/LOI
+

--- a/docs/research/users/pn3-policy-impact-center.md
+++ b/docs/research/users/pn3-policy-impact-center.md
@@ -1,0 +1,26 @@
+# Prenatal-to-3 Policy Impact Center (Pn3 PIC)
+
+Segment: Research/Policy
+Region: US
+Status: Prospect (verify relationship)
+
+## Quick Facts
+- Contact(s): TBD
+- Product fit: Policy Scoring; Distributional Analysis; Rules-as-Data
+- Current usage: Unknown — confirm any engagement
+
+## Revenue Projection Inputs
+- Pricing model: Institutional license or hosted instance
+- Assumptions: research grants; collaborative pilots
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Website: https://pn3policy.org/
+- [ ] Contact + scope
+- [ ] Budget/Spend estimate
+
+## Next Actions
+- [ ] Intro outreach
+- [ ] Joint scoping of pilot/research project
+- [ ] Funding and timeline definition
+

--- a/docs/research/users/retail-companies.md
+++ b/docs/research/users/retail-companies.md
@@ -1,0 +1,23 @@
+# Retail Companies
+
+Segment: Retail/CPG Analytics
+Region: US initially
+Status: Prospect (segment)
+
+## Quick Facts
+- Contacts: analytics leads at retailers/CPG; network planning teams
+- Product fit: Local Demand Estimation; scenario API for policy impacts
+
+## Revenue Projection Inputs
+- Pricing model: enterprise data subscription + advisory pilots
+- Assumptions: # enterprise customers; ACV; usage
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Prospective company list
+- [ ] Use case interviews and budget confirmation
+
+## Next Actions
+- [ ] Identify 3 lighthouse accounts
+- [ ] Pilot scope and data requirements
+

--- a/docs/research/users/tax-consultancies.md
+++ b/docs/research/users/tax-consultancies.md
@@ -1,0 +1,23 @@
+# Tax Consultancies
+
+Segment: Consulting
+Region: US/UK
+Status: Prospect (segment)
+
+## Quick Facts
+- Contacts: boutique + large policy/tax consultancies
+- Product fit: Policy Scoring; Distributional Analysis; Rules-as-Data
+
+## Revenue Projection Inputs
+- Pricing model: per-project platform fees + annual platform subscription
+- Assumptions: projects/year; platform fee per project
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Market sizing for policy consulting
+- [ ] Example engagements and budgets
+
+## Next Actions
+- [ ] Outreach and reference project scoping
+- [ ] Create reference templates (notebooks, charts)
+

--- a/docs/research/users/the-tax-project.md
+++ b/docs/research/users/the-tax-project.md
@@ -1,0 +1,26 @@
+# The Tax Project
+
+Segment: Media/Research
+Region: US
+Status: In Progress (confirm)
+
+## Quick Facts
+- Contact(s): TBD
+- Product fit: Tax Calculator; Policy Scoring; distributional analysis
+- Current usage: TBD (confirm API or hosted)
+
+## Revenue Projection Inputs
+- Pricing model: Hosted instance or API usage; sponsorship model possible
+- Assumptions: runs/month; traffic-driven variability
+- Low/Base/High: fill in `docs/research/revenue_projections.csv`
+
+## Evidence
+- [ ] Website: https://www.thetaxproject.com/
+- [ ] Usage confirmation
+- [ ] Budget/Spend estimate
+
+## Next Actions
+- [ ] Intro or reconfirm scope
+- [ ] Define KPI and timeline
+- [ ] Pricing discussion and SOW/LOI
+

--- a/mcp/playwright-server.mjs
+++ b/mcp/playwright-server.mjs
@@ -1,0 +1,102 @@
+// Minimal MCP server exposing browser automation via Playwright.
+// Note: This is a basic, single-session server intended for local use.
+import { chromium } from 'playwright';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/transport/stdiotransport';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+let browser;
+let page;
+
+async function ensureBrowser() {
+  if (!browser) {
+    browser = await chromium.launch({ headless: process.env.HEADLESS !== 'false' });
+    const context = await browser.newContext();
+    page = await context.newPage();
+  }
+  return page;
+}
+
+const server = new Server({
+  name: 'cosilico-playwright-mcp',
+  version: '0.1.0',
+});
+
+server.tool('goto', {
+  description: 'Navigate to a URL',
+  inputSchema: {
+    type: 'object',
+    properties: { url: { type: 'string' } },
+    required: ['url'],
+  },
+  handler: async ({ url }) => {
+    const p = await ensureBrowser();
+    await p.goto(url);
+    return { ok: true };
+  },
+});
+
+server.tool('click', {
+  description: 'Click an element by text or selector',
+  inputSchema: {
+    type: 'object',
+    properties: { text: { type: 'string' }, selector: { type: 'string' } },
+  },
+  handler: async ({ text, selector }) => {
+    const p = await ensureBrowser();
+    if (selector) {
+      await p.click(selector);
+    } else if (text) {
+      await p.getByText(text, { exact: true }).click();
+    } else {
+      throw new Error('Provide text or selector');
+    }
+    return { ok: true };
+  },
+});
+
+server.tool('fill', {
+  description: 'Fill into an input/textarea by selector',
+  inputSchema: { type: 'object', properties: { selector: { type: 'string' }, value: { type: 'string' } }, required: ['selector', 'value'] },
+  handler: async ({ selector, value }) => {
+    const p = await ensureBrowser();
+    await p.fill(selector, value);
+    return { ok: true };
+  },
+});
+
+server.tool('text', {
+  description: 'Extract page text content for a selector',
+  inputSchema: { type: 'object', properties: { selector: { type: 'string' } }, required: ['selector'] },
+  handler: async ({ selector }) => {
+    const p = await ensureBrowser();
+    const content = await p.textContent(selector);
+    return { content };
+  },
+});
+
+server.tool('screenshot', {
+  description: 'Take a PNG screenshot of the page',
+  inputSchema: { type: 'object', properties: { fullPage: { type: 'boolean' } } },
+  handler: async ({ fullPage = true }) => {
+    const p = await ensureBrowser();
+    const buffer = await p.screenshot({ fullPage });
+    return { base64: buffer.toString('base64') };
+  },
+});
+
+server.tool('assert', {
+  description: 'Assert that text appears on the page',
+  inputSchema: { type: 'object', properties: { text: { type: 'string' } }, required: ['text'] },
+  handler: async ({ text }) => {
+    const p = await ensureBrowser();
+    await p.getByText(text).waitFor();
+    return { ok: true };
+  },
+});
+
+process.on('SIGINT', async () => { if (browser) await browser.close(); process.exit(0); });
+process.on('SIGTERM', async () => { if (browser) await browser.close(); process.exit(0); });
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+

--- a/public/data/business/edges.yaml
+++ b/public/data/business/edges.yaml
@@ -1,0 +1,250 @@
+- from: cust_policyengine
+  to: uc_tax_calc
+- from: cust_policyengine
+  to: uc_scoring
+- from: cust_policyengine
+  to: uc_dist
+
+- from: cust_gov
+  to: uc_scoring
+- from: cust_gov
+  to: uc_dist
+- from: cust_gov
+  to: uc_audit
+
+- from: cust_ai
+  to: uc_microdata
+- from: cust_ai
+  to: uc_scenarios
+
+- from: cust_research
+  to: uc_microdata
+- from: cust_research
+  to: uc_ge
+
+- from: cust_fintech
+  to: uc_tax_calc
+- from: cust_fintech
+  to: uc_benefit
+
+# New customer -> use case links (API customers)
+- from: cust_myfriendben
+  to: uc_benefit
+- from: cust_myfriendben
+  to: uc_tax_calc
+
+- from: cust_benefitnav
+  to: uc_benefit
+
+- from: cust_impactica
+  to: uc_benefit
+- from: cust_impactica
+  to: uc_benefit_orch
+
+- from: cust_mirza
+  to: uc_benefit
+- from: cust_mirza
+  to: uc_tax_calc
+
+- from: cust_taxproject
+  to: uc_tax_calc
+  
+# Segment customers
+- from: cust_accounting
+  to: uc_tax_prep
+- from: cust_accounting
+  to: uc_payroll
+- from: cust_accounting
+  to: uc_rules_data
+
+- from: cust_tax_consult
+  to: uc_scoring
+- from: cust_tax_consult
+  to: uc_dist
+
+- from: cust_gov_ops
+  to: uc_benefit_orch
+- from: cust_gov_ops
+  to: uc_audit
+
+# Data-centric segments
+- from: cust_market_research
+  to: uc_local_demand
+- from: cust_market_research
+  to: uc_rules_data
+- from: cust_retail
+  to: uc_local_demand
+
+# UseCase -> Product
+- from: uc_tax_calc
+  to: prod_rest
+- from: uc_tax_calc
+  to: prod_python
+- from: uc_benefit
+  to: prod_rest
+- from: uc_scoring
+  to: prod_python
+- from: uc_scoring
+  to: prod_hosted
+- from: uc_dist
+  to: prod_python
+- from: uc_microdata
+  to: prod_rest
+- from: uc_ge
+  to: prod_python
+- from: uc_scenarios
+  to: prod_playground
+- from: uc_audit
+  to: prod_hosted
+
+# New use cases -> products
+- from: uc_tax_prep
+  to: prod_rest
+- from: uc_tax_prep
+  to: prod_python
+
+- from: uc_payroll
+  to: prod_rest
+- from: uc_payroll
+  to: prod_hosted
+
+- from: uc_benefit_orch
+  to: prod_hosted
+- from: uc_benefit_orch
+  to: prod_rest
+
+- from: uc_rules_data
+  to: prod_rest
+- from: uc_rules_data
+  to: prod_data_packs
+
+- from: uc_change_tracking
+  to: prod_data_packs
+- from: uc_change_tracking
+  to: prod_rest
+
+- from: uc_llm_policy
+  to: prod_rest
+
+- from: uc_local_demand
+  to: prod_data_packs
+- from: uc_local_demand
+  to: prod_rest
+
+# Product -> Capability
+- from: prod_rest
+  to: cap_rules
+- from: prod_rest
+  to: cap_data
+- from: prod_python
+  to: cap_rules
+- from: prod_python
+  to: cap_behavior
+- from: prod_playground
+  to: cap_rules
+- from: prod_hosted
+  to: cap_validation
+- from: prod_private
+  to: cap_versioning
+- from: prod_data_packs
+  to: cap_data
+- from: uc_ge
+  to: cap_ge
+
+# Capability -> Resource
+- from: cap_rules
+  to: res_core_eng
+- from: cap_data
+  to: res_data_eng
+- from: cap_behavior
+  to: res_econ
+- from: cap_ge
+  to: res_econ
+- from: cap_validation
+  to: res_core_eng
+- from: cap_versioning
+  to: res_core_eng
+- from: prod_hosted
+  to: res_sre
+- from: prod_playground
+  to: res_design
+- from: prod_python
+  to: res_devrel
+
+# Revenue
+- from: prod_hosted
+  to: rev_sla
+- from: prod_private
+  to: rev_private
+- from: cust_gov
+  to: rev_custom
+- from: cust_ai
+  to: rev_custom
+- from: prod_playground
+  to: rev_training
+
+# Costs
+- from: prod_hosted
+  to: cost_compute
+- from: prod_hosted
+  to: cost_storage
+- from: rev_sla
+  to: cost_support
+- from: prod_private
+  to: cost_compliance
+
+# Risks
+- from: res_core_eng
+  to: risk_migration
+- from: cust_policyengine
+  to: risk_brand
+- from: cap_data
+  to: risk_quality
+- from: uc_scoring
+  to: risk_adoption
+
+# Metrics
+- from: prod_rest
+  to: met_maus
+- from: prod_python
+  to: met_maus
+- from: cap_rules
+  to: met_coverage
+- from: prod_hosted
+  to: met_latency
+- from: prod_rest
+  to: met_success
+- from: partner_universities
+  to: met_contribs
+
+# Partners
+- from: cust_research
+  to: partner_universities
+- from: cust_gov
+  to: partner_agencies
+- from: cust_policyengine
+  to: partner_foundations
+
+# Competitors to UseCases
+- from: comp_openfisca
+  to: uc_tax_calc
+- from: comp_openfisca
+  to: uc_benefit
+- from: comp_taxcalc
+  to: uc_tax_calc
+- from: comp_taxsim
+  to: uc_tax_calc
+- from: comp_euromod
+  to: uc_dist
+- from: comp_euromod
+  to: uc_scoring
+- from: comp_taxben
+  to: uc_benefit
+- from: comp_spsdm
+  to: uc_scoring
+- from: comp_openmpp
+  to: uc_scenarios
+- from: comp_liam2
+  to: uc_scenarios
+- from: comp_jasmine
+  to: uc_ge

--- a/public/data/business/nodes.yaml
+++ b/public/data/business/nodes.yaml
@@ -1,0 +1,459 @@
+- id: cust_policyengine
+  label: PolicyEngine Nonprofit
+  type: Customer
+  tags: [flagship]
+  meta:
+    status: validated
+    notes: Flagship client building public-interest apps on Cosilico
+    evidence:
+      - title: PolicyEngine website
+        url: https://policyengine.org
+        date: 2025-08-31
+
+- id: cust_gov
+  label: Government Agencies
+  type: Customer
+  tags: [public]
+  meta:
+    status: in_progress
+    notes: Fiscal/social policy teams in federal and state agencies
+    tam: 0  # TODO: fill with sourced estimate
+    sam: 0  # TODO: regions you cover
+    som: 0  # TODO: 12–24m achievable
+    evidence:
+      - title: Research needed — fiscal note and policy analytics contracts
+        kind: tam
+
+- id: cust_ai
+  label: AI Companies
+  type: Customer
+  tags: [ai]
+  meta:
+    status: unresearched
+    tam: 0
+    sam: 0
+    som: 0
+    evidence:
+      - title: Research needed — AI policy assistants addressable market
+        kind: tam
+
+- id: cust_research
+  label: Research Institutes
+  type: Customer
+  tags: [academic]
+  meta:
+    status: unresearched
+    tam: 0
+    sam: 0
+    som: 0
+    evidence:
+      - title: Research needed — academic institutional licenses
+        kind: tam
+
+- id: cust_fintech
+  label: Fintech Apps
+  type: Customer
+  tags: [consumer]
+  meta:
+    status: unresearched
+    tam: 0
+    sam: 0
+    som: 0
+    evidence:
+      - title: Research needed — benefits fintech/API spend
+        kind: tam
+
+# Additional concrete API customers
+- id: cust_myfriendben
+  label: MyFriendBen
+  type: Customer
+  tags: [api, us]
+  meta:
+    status: validated
+    notes: API customer for benefits screening and tax interactions
+
+- id: cust_benefitnav
+  label: Benefit Navigator
+  type: Customer
+  tags: [api, us]
+  meta:
+    status: validated
+    notes: API customer focused on benefits discovery and eligibility
+
+- id: cust_impactica
+  label: Impactica (Navvy)
+  type: Customer
+  tags: [api, us]
+  meta:
+    status: validated
+    notes: Building Navvy for the Student Basic Needs Coalition
+
+- id: cust_mirza
+  label: Mirza
+  type: Customer
+  tags: [api, uk]
+  meta:
+    status: in_progress
+    notes: Childcare affordability and benefits planning
+    tam: 0
+    sam: 0
+    som: 0
+
+- id: cust_taxproject
+  label: The Tax Project
+  type: Customer
+  tags: [api, us]
+  meta:
+    status: in_progress
+    notes: Tax analysis and calculator use cases
+    tam: 0
+    sam: 0
+    som: 0
+
+# Prospective/segment customers
+- id: cust_market_research
+  label: Market Research Orgs
+  type: Customer
+  tags: [segment, data, us]
+  meta:
+    status: unresearched
+    notes: Local demand estimation using enriched microdata
+    tam: 0
+    sam: 0
+    som: 0
+
+- id: cust_retail
+  label: Retail Companies
+  type: Customer
+  tags: [segment, data, us]
+  meta:
+    status: unresearched
+    notes: Store planning and assortment via county-level demand
+    tam: 0
+    sam: 0
+    som: 0
+- id: cust_accounting
+  label: Accounting Firms
+  type: Customer
+  tags: [segment, us, uk]
+  meta:
+    status: in_progress
+    notes: Advisory, tax prep, and payroll integrations
+    tam: 0
+    sam: 0
+    som: 0
+    evidence:
+      - title: Research needed — US/UK firm counts × attach rate
+        kind: tam
+
+- id: cust_tax_consult
+  label: Tax Consultancies
+  type: Customer
+  tags: [segment, us, uk]
+  meta:
+    status: unresearched
+    notes: Policy scoring and distributional analysis services
+    tam: 0
+    sam: 0
+    som: 0
+    evidence:
+      - title: Research needed — policy consulting market sizing
+        kind: tam
+
+- id: cust_gov_ops
+  label: Gov Program Operators
+  type: Customer
+  tags: [public, us, uk]
+  meta:
+    status: unresearched
+    notes: Operating benefit programs (eligibility, adjudication, audit)
+    tam: 0
+    sam: 0
+    som: 0
+
+# Use cases
+- id: uc_tax_calc
+  label: Tax Calculator
+  type: UseCase
+
+- id: uc_benefit
+  label: Benefit Eligibility
+  type: UseCase
+
+- id: uc_scoring
+  label: Policy Scoring
+  type: UseCase
+
+- id: uc_dist
+  label: Distributional Analysis
+  type: UseCase
+
+- id: uc_microdata
+  label: Microdata API
+  type: UseCase
+
+- id: uc_ge
+  label: GE Modeling
+  type: UseCase
+
+- id: uc_scenarios
+  label: Scenario Planning
+  type: UseCase
+
+- id: uc_audit
+  label: Audit Trails
+  type: UseCase
+
+# New use cases
+- id: uc_tax_prep
+  label: Tax Prep & Advisory
+  type: UseCase
+
+- id: uc_payroll
+  label: Payroll & Withholding
+  type: UseCase
+
+- id: uc_benefit_orch
+  label: Benefit Application Orchestration
+  type: UseCase
+
+- id: uc_rules_data
+  label: Rules-as-Data
+  type: UseCase
+
+- id: uc_change_tracking
+  label: Policy Change Tracking
+  type: UseCase
+
+- id: uc_llm_policy
+  label: LLM Policy Reasoning
+  type: UseCase
+
+- id: uc_local_demand
+  label: Local Demand Estimation
+  type: UseCase
+
+# Products
+- id: prod_playground
+  label: Playground
+  type: Product
+
+- id: prod_python
+  label: Python SDK
+  type: Product
+
+- id: prod_rest
+  label: REST API
+  type: Product
+
+- id: prod_hosted
+  label: Hosted Platform
+  type: Product
+
+- id: prod_private
+  label: Private Deployment
+  type: Product
+
+- id: prod_data_packs
+  label: Data Packs
+  type: Product
+
+# Capabilities
+- id: cap_rules
+  label: Rules Engine
+  type: Capability
+
+- id: cap_data
+  label: Microdata Synthesizer
+  type: Capability
+
+- id: cap_behavior
+  label: Behavioral Models
+  type: Capability
+
+- id: cap_ge
+  label: GE Solver
+  type: Capability
+
+- id: cap_validation
+  label: Validation Suite
+  type: Capability
+
+- id: cap_versioning
+  label: Versioning
+  type: Capability
+
+# Resources
+- id: res_core_eng
+  label: Core Engineering
+  type: Resource
+
+- id: res_data_eng
+  label: Data Engineering
+  type: Resource
+
+- id: res_econ
+  label: Economists/Modelers
+  type: Resource
+
+- id: res_devrel
+  label: DevRel/Docs
+  type: Resource
+
+- id: res_sre
+  label: SRE/Ops
+  type: Resource
+
+- id: res_design
+  label: Design/UX
+  type: Resource
+
+# Revenues
+- id: rev_sla
+  label: Enterprise SLAs
+  type: Revenue
+
+- id: rev_custom
+  label: Custom Development
+  type: Revenue
+
+- id: rev_private
+  label: Private Extensions
+  type: Revenue
+
+- id: rev_training
+  label: Training & Workshops
+  type: Revenue
+
+# Costs
+- id: cost_compute
+  label: Compute
+  type: Cost
+
+- id: cost_storage
+  label: Storage
+  type: Cost
+
+- id: cost_support
+  label: Support
+  type: Cost
+
+- id: cost_compliance
+  label: Compliance
+  type: Cost
+
+# Risks
+- id: risk_migration
+  label: Migration Complexity
+  type: Risk
+
+- id: risk_brand
+  label: Brand Confusion
+  type: Risk
+
+- id: risk_quality
+  label: Data Quality
+  type: Risk
+
+- id: risk_adoption
+  label: Adoption
+  type: Risk
+
+# Metrics
+- id: met_maus
+  label: API MAUs
+  type: Metric
+
+- id: met_coverage
+  label: Jurisdiction Coverage
+  type: Metric
+
+- id: met_latency
+  label: Run Latency
+  type: Metric
+
+- id: met_success
+  label: Success Rate
+  type: Metric
+
+- id: met_contribs
+  label: Contributions
+  type: Metric
+
+# Partners
+- id: partner_universities
+  label: Universities
+  type: Partner
+
+- id: partner_agencies
+  label: Agencies
+  type: Partner
+
+- id: partner_foundations
+  label: Foundations
+  type: Partner
+
+# Competitors
+- id: comp_openfisca
+  label: OpenFisca
+  type: Competitor
+  tags: [oss]
+  meta:
+    status: in_progress
+    oss: true
+
+- id: comp_taxcalc
+  label: Tax-Calculator (PSL)
+  type: Competitor
+  tags: [oss]
+  meta:
+    status: in_progress
+    oss: true
+
+- id: comp_taxsim
+  label: NBER TAXSIM
+  type: Competitor
+  meta:
+    status: unresearched
+
+- id: comp_euromod
+  label: EUROMOD
+  type: Competitor
+  meta:
+    status: unresearched
+
+- id: comp_taxben
+  label: OECD TaxBEN
+  type: Competitor
+  meta:
+    status: unresearched
+
+- id: comp_spsdm
+  label: SPSD/M
+  type: Competitor
+  meta:
+    status: unresearched
+
+- id: comp_openmpp
+  label: OpenM++
+  type: Competitor
+  tags: [oss]
+  meta:
+    status: unresearched
+    oss: true
+
+- id: comp_liam2
+  label: LIAM2
+  type: Competitor
+  tags: [oss]
+  meta:
+    status: unresearched
+    oss: true
+
+- id: comp_jasmine
+  label: JAS-MINE
+  type: Competitor
+  tags: [oss]
+  meta:
+    status: unresearched
+    oss: true

--- a/public/data/business_research.template.json
+++ b/public/data/business_research.template.json
@@ -1,0 +1,18 @@
+{
+  "cust_policyengine": { "status": "validated", "evidence": [], "notes": "Flagship client" },
+  "cust_gov": { "status": "in_progress", "tam": null, "sam": null, "som": null, "evidence": [], "notes": "Gov fiscal/social policy teams" },
+  "cust_ai": { "status": "unresearched", "tam": null, "sam": null, "som": null, "evidence": [], "notes": "AI companies building policy/finance copilots" },
+  "cust_research": { "status": "unresearched", "tam": null, "sam": null, "som": null, "evidence": [], "notes": "Universities and institutes" },
+  "cust_fintech": { "status": "unresearched", "tam": null, "sam": null, "som": null, "evidence": [], "notes": "Consumer and SMB finance apps" },
+
+  "comp_openfisca": { "status": "in_progress", "oss": true, "license": "", "website": "", "pricing": "", "strengths": "", "weaknesses": "", "evidence": [] },
+  "comp_taxcalc": { "status": "in_progress", "oss": true, "license": "", "website": "", "pricing": "", "strengths": "", "weaknesses": "", "evidence": [] },
+  "comp_taxsim": { "status": "unresearched", "oss": null, "license": "", "website": "", "pricing": "", "strengths": "", "weaknesses": "", "evidence": [] },
+  "comp_euromod": { "status": "unresearched", "oss": null, "license": "", "website": "", "pricing": "", "strengths": "", "weaknesses": "", "evidence": [] },
+  "comp_taxben": { "status": "unresearched", "oss": null, "license": "", "website": "", "pricing": "", "strengths": "", "weaknesses": "", "evidence": [] },
+  "comp_spsdm": { "status": "unresearched", "oss": null, "license": "", "website": "", "pricing": "", "strengths": "", "weaknesses": "", "evidence": [] },
+  "comp_openmpp": { "status": "unresearched", "oss": true, "license": "", "website": "", "pricing": "", "strengths": "", "weaknesses": "", "evidence": [] },
+  "comp_liam2": { "status": "unresearched", "oss": true, "license": "", "website": "", "pricing": "", "strengths": "", "weaknesses": "", "evidence": [] },
+  "comp_jasmine": { "status": "unresearched", "oss": true, "license": "", "website": "", "pricing": "", "strengths": "", "weaknesses": "", "evidence": [] }
+}
+


### PR DESCRIPTION
## Summary

- Add market research documentation covering user segments, potential customers, revenue projections, and international expansion
- Add business plan data files (nodes.yaml, edges.yaml) used by BusinessPlanExplorer
- Add Playwright MCP server for browser automation tooling

## Test plan

- [ ] Documentation renders correctly on GitHub
- [ ] Data files are valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)